### PR TITLE
Fix KDiff3 & Nexus Mod Manager Compaitibility Issues Regarding Symbolic Links

### DIFF
--- a/WitcherScriptMerger/Extensions.cs
+++ b/WitcherScriptMerger/Extensions.cs
@@ -8,6 +8,8 @@ using System.Windows.Forms;
 
 namespace WitcherScriptMerger
 {
+    using System.IO;
+
     static class Extensions
     {
         #region Strings
@@ -52,6 +54,12 @@ namespace WitcherScriptMerger
         public static string GetPluralS(this int num)
         {
             return num == 1 ? "" : "s";
+        }
+
+        public static string ResolveTargetFileFullName(this string fileFullName)
+        {
+            var fileInfo = new FileInfo(fileFullName);
+            return fileInfo.Exists ? SimLink.GetSymbolicLinkTarget(fileInfo) : fileInfo.FullName;
         }
 
         #endregion

--- a/WitcherScriptMerger/Extensions.cs
+++ b/WitcherScriptMerger/Extensions.cs
@@ -56,12 +56,13 @@ namespace WitcherScriptMerger
             return num == 1 ? "" : "s";
         }
 
-        public static string ResolveTargetFileFullName(this string fileFullName)
+        #endregion
+
+        #region FileInfo
+        public static string ResolveTargetFileFullName(this FileInfo fileInfo)
         {
-            var fileInfo = new FileInfo(fileFullName);
             return fileInfo.Exists ? SimLink.GetSymbolicLinkTarget(fileInfo) : fileInfo.FullName;
         }
-
         #endregion
 
         #region Tree & Context Menu

--- a/WitcherScriptMerger/SimLink.cs
+++ b/WitcherScriptMerger/SimLink.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace WitcherScriptMerger
+{
+    /// <summary>
+    ///     Provides access to NTFS junction points in .Net.
+    /// </summary>
+    public static class SimLink
+    {
+        private const int CREATION_DISPOSITION_OPEN_EXISTING = 3;
+
+        private const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+
+        // http://msdn.microsoft.com/en-us/library/aa364962%28VS.85%29.aspx
+        [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", CharSet = CharSet.Unicode,
+            SetLastError = true)]
+        public static extern int GetFinalPathNameByHandle(IntPtr handle,
+            [In, Out] StringBuilder path,
+            int bufLen,
+            int flags);
+
+        // http://msdn.microsoft.com/en-us/library/aa363858(VS.85).aspx
+        [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern SafeFileHandle CreateFile(string lpFileName,
+            int dwDesiredAccess,
+            int dwShareMode,
+            IntPtr SecurityAttributes,
+            int dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        public static string GetSymbolicLinkTarget(FileInfo symlink)
+        {
+            var fileHandle = CreateFile(symlink.FullName, 0, 2, IntPtr.Zero, CREATION_DISPOSITION_OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero);
+            if (fileHandle.IsInvalid)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            var path = new StringBuilder(512);
+            var size = GetFinalPathNameByHandle(fileHandle.DangerousGetHandle(), path, path.Capacity, 0);
+            if (size < 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+            // The remarks section of GetFinalPathNameByHandle mentions the return being prefixed with "\\?\"
+            // More information about "\\?\" here -> http://msdn.microsoft.com/en-us/library/aa365247(v=VS.85).aspx
+            if (path[0] == '\\' && path[1] == '\\' && path[2] == '?' && path[3] == '\\')
+            {
+                return path.ToString().Substring(4);
+            }
+            return path.ToString();
+        }
+    }
+}

--- a/WitcherScriptMerger/Tools/KDiff3.cs
+++ b/WitcherScriptMerger/Tools/KDiff3.cs
@@ -55,7 +55,7 @@ namespace WitcherScriptMerger.Tools
 
             if (!Program.Settings.Get<bool>("ReviewEachMerge") && hasVanillaVersion)
             {
-                if (source1FullName.EqualsIgnoreCase(source2FullName)
+                if (source1FullName.EqualsIgnoreCase(outputPath)
                     && source2.Hash != null && source2.Hash.IsOutdated)
                 {
                     Program.MainForm.ShowMessage(

--- a/WitcherScriptMerger/Tools/KDiff3.cs
+++ b/WitcherScriptMerger/Tools/KDiff3.cs
@@ -32,8 +32,12 @@ namespace WitcherScriptMerger.Tools
                 ? "\"" + vanillaFile.FullName + "\" "
                 : "");
 
+            // resolve any simlinked files
+            var source1FullName = source1.TextFile.FullName.ResolveTargetFileFullName();
+            var source2FullName = source2.TextFile.FullName.ResolveTargetFileFullName();
+
             args +=
-                $"\"{source1.TextFile.FullName}\" \"{source2.TextFile.FullName}\" " +
+                $"\"{source1FullName}\" \"{source2FullName}\" " +
                 $"-o \"{outputPath}\" " +
                 "--cs \"WhiteSpace3FileMergeDefault=2\" " +
                 "--cs \"CreateBakFiles=0\" " +
@@ -51,7 +55,7 @@ namespace WitcherScriptMerger.Tools
 
             if (!Program.Settings.Get<bool>("ReviewEachMerge") && hasVanillaVersion)
             {
-                if (source1.TextFile.FullName.EqualsIgnoreCase(outputPath)
+                if (source1FullName.EqualsIgnoreCase(source2FullName)
                     && source2.Hash != null && source2.Hash.IsOutdated)
                 {
                     Program.MainForm.ShowMessage(

--- a/WitcherScriptMerger/Tools/KDiff3.cs
+++ b/WitcherScriptMerger/Tools/KDiff3.cs
@@ -33,8 +33,8 @@ namespace WitcherScriptMerger.Tools
                 : "");
 
             // resolve any simlinked files
-            var source1FullName = source1.TextFile.FullName.ResolveTargetFileFullName();
-            var source2FullName = source2.TextFile.FullName.ResolveTargetFileFullName();
+            var source1FullName = source1.TextFile.ResolveTargetFileFullName();
+            var source2FullName = source2.TextFile.ResolveTargetFileFullName();
 
             args +=
                 $"\"{source1FullName}\" \"{source2FullName}\" " +

--- a/WitcherScriptMerger/WitcherScriptMerger.csproj
+++ b/WitcherScriptMerger/WitcherScriptMerger.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Forms\OptionsForm.Designer.cs">
       <DependentUpon>OptionsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="SimLink.cs" />
     <Compile Include="Tools\xxHash.cs" />
     <Compile Include="FileIndex\ModFile.cs" />
     <Compile Include="FileIndex\ModFileCategory.cs" />


### PR DESCRIPTION
Added junction/symlinks pre-processing for file paths when calling KDiff3, as KDiff3 does not follow symlinks/junctions when passed as arguments from the command line. I could not find any documentation about this particular error regarding KDiff3, so I suspect it may be an issue with Windows 10, but have no evidence to back it up. Furthermore, its my personal preference to parse such things on our end anyway.

This is a very quick & untested implementation that only checks paths for the "B" and "C" files during merge that specifically fixes the issue with Nexus Mod Manager using symbolic links and the failure of KDiff3 to parse them (despite its settings being set to follow links). 

Unfortunately, I could not derive the root cause of the issue with KDiff3 not following the symlink. In fact, after KDiff3 opens with "B" & "C" files blank and showing the original link path, you can simply click the file browser for each file and immediately click "OK" to force KDiff3 to follow the link. Of course this is not usable for our purposes. 

Feel free to tweak this or make it more robust. The extension method can be used on both symlink'd and non simlink'd fileInfos. 